### PR TITLE
Incorrect service name

### DIFF
--- a/tools/chocolateybeforemodify.ps1
+++ b/tools/chocolateybeforemodify.ps1
@@ -1,4 +1,4 @@
 ﻿# This runs in 0.9.10+ before upgrade and uninstall.
 # Use this file to do things like stop services prior to upgrade or uninstall.
 
-Stop-Service -Name "Tailscale IPN"
+Stop-Service -Name "Tailscale"


### PR DESCRIPTION
Service name in Windows is 'Tailscale'. Package currently returns non-exit error on upgrade.