### PR TITLE
checksum miss

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -15,7 +15,7 @@ $packageArgs = @{
 
   softwareName   = 'Tailscale'
 
-  checksum       = 'ef280ca5b3bd3c2abc315d94c6cf5f1054fe7f1cf0c97b6272440659b748456e'
+  checksum       = '23301d34779d8900f4c126a71bec127c92dad5ae8c5f30efcf241ac78ed11be6'
   checksumType   = 'sha256'
 
   silentArgs     = '/S'


### PR DESCRIPTION
PS C:\Users\reiji\Downloads> certutil -hashfile .\tailscale-ipn-setup-1.26.2.exe sha256
SHA256 ハッシュ (対象 .\tailscale-ipn-setup-1.26.2.exe):
**23301d34779d8900f4c126a71bec127c92dad5ae8c5f30efcf241ac78ed11be6**
CertUtil: -hashfile コマンドは正常に完了しました。


PS C:\Users\reiji\Downloads> certutil -hashfile .\tailscale-ipn-setup-1.26.1.exe sha256
SHA256 ハッシュ (対象 .\tailscale-ipn-setup-1.26.1.exe):
**ef280ca5b3bd3c2abc315d94c6cf5f1054fe7f1cf0c97b6272440659b748456e**
CertUtil: -hashfile コマンドは正常に完了しました。