### PR TITLE
Update to version 1.34.2 (and switch to MSIs)

### DIFF
--- a/tailscale.nuspec
+++ b/tailscale.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>tailscale</id>
-    <version>1.34.1</version>
+    <version>1.34.2</version>
     <packageSourceUrl>https://github.com/zombiezen/tailscale-choco</packageSourceUrl>
     <owners>zombiezen</owners>
     <!-- == SOFTWARE SPECIFIC SECTION == -->

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -4,22 +4,35 @@ $toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
 Get-ChildItem -Path "$toolsDir\tailscale.cer" | Import-Certificate -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
 
-$url = 'https://pkgs.tailscale.com/stable/tailscale-ipn-setup-1.34.1.exe'
-
-
 $packageArgs = @{
-  packageName    = $env:ChocolateyPackageName
-  unzipLocation  = $toolsDir
-  fileType       = 'exe'
-  url            = $url
+  SoftwareName   = 'Tailscale'
+  PackageName    = $env:ChocolateyPackageName
+  UnzipLocation  = $toolsDir
+  FileType       = 'msi'
 
-  softwareName   = 'Tailscale'
-
-  checksum       = '302b5ef05ad97d39c81624d77882b67adfef2e68da4c9e2a9ebbf5667c29a3b0'
-  checksumType   = 'sha256'
-
-  silentArgs     = '/S'
+  silentArgs     = '/quiet'
   validExitCodes = @(0)
+}
+
+if ($env:PROCESSOR_IDENTIFIER.StartsWith('ARMv')) {
+  # Windows on ARM
+  $packageArgs += @{
+    Url          = 'https://pkgs.tailscale.com/stable/tailscale-setup-1.34.2-arm64.msi'
+    Checksum     = '41bd41724075059fbac5b460081dd8535265444cc2db1c32b68aa16e5f0514cd'
+    ChecksumType = 'sha256'
+  }
+}
+else {
+  # Windows on x86 or x64
+  $packageArgs += @{
+    Url            = 'https://pkgs.tailscale.com/stable/tailscale-setup-1.34.2-x86.msi'
+    Checksum       = '9e9868fed2823f8e16f0f2f858a863d4a4b8ba31e9dfe95d9ca5d556c52858cc'
+    ChecksumType   = 'sha256'
+
+    Url64Bit       = 'https://pkgs.tailscale.com/stable/tailscale-setup-1.34.2-amd64.msi'
+    Checksum64     = 'cf065a8700bb9b4543a8aca1cb377378cd7c7115f68a65ea7a9d44d4346081ff'
+    ChecksumType64 = 'sha256'
+  }
 }
 
 Install-ChocolateyPackage @packageArgs

--- a/updater.ps1
+++ b/updater.ps1
@@ -1,11 +1,17 @@
+function Get-RemoteSHA256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url
+    )
+
+    (Get-FileHash -Algorithm SHA256 -InputStream ([System.Net.WebClient]::new().OpenRead($url))).Hash.ToLower()
+}
+
 $channel = "https://pkgs.tailscale.com/stable/"
 
 $meta = Invoke-WebRequest ($channel + "?mode=json&os=windows") | ConvertFrom-Json
 
-$url = $channel + $meta.Exes[0]
 $version = $meta.Version
-
-$hash = (Get-FileHash -Algorithm SHA256 -InputStream ([System.Net.WebClient]::new().OpenRead($url))).Hash.ToLower()
 
 # Update the nuspec
 $nuspec = New-Object xml
@@ -15,8 +21,15 @@ $nuspec.Save("$PSScriptRoot/tailscale.nuspec")
 
 # Update the installer script
 $installer = Get-Content "./tools/chocolateyinstall.ps1"
-$installer = $installer -replace "https:\/\/pkgs.tailscale.com\/.*\.exe", $url
-$installer = $installer -replace "[0-9a-f]{64}", $hash
+$url = $channel + $meta.MSIs.arm64
+$installer[19] = $installer[19] -replace "https:\/\/pkgs.tailscale.com\/.*\.msi", $url
+$installer[20] = $installer[20] -replace "[0-9a-f]{64}", (Get-RemoteSHA256 $url)
+$url = $channel + $meta.MSIs.x86
+$installer[27] = $installer[27] -replace "https:\/\/pkgs.tailscale.com\/.*\.msi", $url
+$installer[28] = $installer[28] -replace "[0-9a-f]{64}", (Get-RemoteSHA256 $url)
+$url = $channel + $meta.MSIs.amd64
+$installer[31] = $installer[31] -replace "https:\/\/pkgs.tailscale.com\/.*\.msi", $url
+$installer[32] = $installer[32] -replace "[0-9a-f]{64}", (Get-RemoteSHA256 $url)
 $installer | Out-File "./tools/chocolateyinstall.ps1"
 
 # Check and see if files have been updated


### PR DESCRIPTION
This includes:
* the normal update to the nuspec
* an update to the install script that uses MSIs instead of the old EXE
* and an update to the updater script to support the new MSI-based install script